### PR TITLE
入渠中艦娘の名前が適切に反映されないバグの修正

### DIFF
--- a/Grabacr07.KanColleWrapper/Models/RepairingDock.cs
+++ b/Grabacr07.KanColleWrapper/Models/RepairingDock.cs
@@ -80,7 +80,7 @@ namespace Grabacr07.KanColleWrapper.Models
 		/// </summary>
 		public Ship Ship
 		{
-			get { return this.State == RepairingDockState.Repairing ? _Ship : null; }
+			get { return this.State == RepairingDockState.Repairing ? this._Ship : null; }
 		}
 
 		#endregion
@@ -158,7 +158,7 @@ namespace Grabacr07.KanColleWrapper.Models
 		internal void UpdateShip()
 		{
 			this._Ship = this.homeport.Ships[this.ShipId];
-			this.RaisePropertyChanged(() => Ship);
+			this.RaisePropertyChanged(() => this.Ship);
 		}
 
 		protected override void Tick()
@@ -174,7 +174,7 @@ namespace Grabacr07.KanColleWrapper.Models
 
 				// 何らかの原因で Ship の作成に失敗していた場合に再設定
 				// 初回起動時等 this.homeport.Ships が不定のタイミングで発生
-				if (null == Ship)
+				if (null == this.Ship)
 				{
 					this.UpdateShip();
 				}


### PR DESCRIPTION
下記2点について修正。
1. ShipId の setter において、this.RaisePropertyChanged("Ship")を呼ぶのみで _Ship を null クリアしていない。
   -> l83 (this._Ship = this.homeport.Ships[this.ShipId]) が古いデータを使い続け、意図した評価がされない。 
2. Ship の getter 内で _Ship を更新するため、複数 view より参照していた場合、他の要素へ変更が波及しない(bukkun.masterでのサイドバー表示時の問題点)。
