### PR TITLE
発生中の任務がない場合のために任務確認処理の位置を変更 (fixed #63)

### DIFF
--- a/Grabacr07.KanColleWrapper/Quests.cs
+++ b/Grabacr07.KanColleWrapper/Quests.cs
@@ -173,11 +173,6 @@ namespace Grabacr07.KanColleWrapper
 				while (this.questPages.Count < questlist.api_page_count) this.questPages.Add(null);
 			}
 
-			var page = questlist.api_disp_page - 1;
-			if (page >= this.questPages.Count) page = this.questPages.Count - 1;
-
-			this.questPages[page] = new ConcurrentDictionary<int, Quest>();
-
 			if (questlist.api_list == null)
 			{
 				this.IsEmpty = true;
@@ -185,6 +180,11 @@ namespace Grabacr07.KanColleWrapper
 			}
 			else
 			{
+				var page = questlist.api_disp_page - 1;
+				if (page >= this.questPages.Count) page = this.questPages.Count - 1;
+
+				this.questPages[page] = new ConcurrentDictionary<int, Quest>();
+
 				this.IsEmpty = false;
 
 				questlist.api_list.Select(x => new Quest(x))


### PR DESCRIPTION
Issue #63 の修正です。
任務ページが0の状態でJSONを読むと配列に-1を渡して止まっていたので分岐の内側に移動しました。
