### PR TITLE
Take the total amount of exp. account into level sort

### DIFF
--- a/Grabacr07.KanColleViewer/ViewModels/Catalogs/SortableColumnViewModel.cs
+++ b/Grabacr07.KanColleViewer/ViewModels/Catalogs/SortableColumnViewModel.cs
@@ -118,12 +118,14 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			if (this.Direction == SortDirection.Ascending)
 			{
 				return list.OrderBy(x => x.Level)
+					.ThenByDescending(x => x.ExpForNextLevel)
 					.ThenBy(x => x.Info.SortId)
 					.ThenBy(x => x.Id);
 			}
 			if (this.Direction == SortDirection.Descending)
 			{
 				return list.OrderByDescending(x => x.Level)
+					.ThenBy(x => x.ExpForNextLevel)
 					.ThenBy(x => x.Info.SortId)
 					.ThenBy(x => x.Id);
 			}
@@ -142,6 +144,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 				return list.OrderBy(x => x.Condition)
 					.ThenBy(x => x.Info.ShipType.Id)
 					.ThenBy(x => x.Level)
+					.ThenByDescending(x => x.ExpForNextLevel)
 					.ThenBy(x => x.Info.SortId);
 			}
 			if (this.Direction == SortDirection.Descending)
@@ -149,6 +152,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 				return list.OrderByDescending(x => x.Condition)
 					.ThenBy(x => x.Info.ShipType.Id)
 					.ThenBy(x => x.Level)
+					.ThenByDescending(x => x.ExpForNextLevel)
 					.ThenBy(x => x.Info.SortId);
 			}
 			return list;
@@ -166,6 +170,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 				return list.OrderBy(x => x.ViewRange)
 					.ThenBy(x => x.Info.ShipType.Id)
 					.ThenBy(x => x.Level)
+					.ThenByDescending(x => x.ExpForNextLevel)
 					.ThenBy(x => x.Info.SortId);
 			}
 			if (this.Direction == SortDirection.Descending)
@@ -173,6 +178,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 				return list.OrderByDescending(x => x.ViewRange)
 					.ThenBy(x => x.Info.ShipType.Id)
 					.ThenBy(x => x.Level)
+					.ThenByDescending(x => x.ExpForNextLevel)
 					.ThenBy(x => x.Info.SortId);
 			}
 			return list;


### PR DESCRIPTION
所有艦娘一覧画面にて、レベルが同じ場合次レベルに達するまでの経験値 `ExpForNextLevel` も考慮してソートしたいです。