### PR TITLE
マスタに海域、マップデータを追加

### DIFF
--- a/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
+++ b/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
@@ -99,6 +99,8 @@
     <Compile Include="Calculator.cs" />
     <Compile Include="Counter.cs" />
     <Compile Include="Dockyard.cs" />
+    <Compile Include="Models\MapArea.cs" />
+    <Compile Include="Models\MapInfo.cs" />
     <Compile Include="Models\Mission.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Itemyard.cs" />
@@ -107,6 +109,8 @@
     <Compile Include="Models\ConditionRejuvenatedEventArgs.cs" />
     <Compile Include="Models\CreatedSlotItem.cs" />
     <Compile Include="Models\FleetCondition.cs" />
+    <Compile Include="Models\Raw\kcsapi_mst_maparea.cs" />
+    <Compile Include="Models\Raw\kcsapi_mst_mapinfo.cs" />
     <Compile Include="Models\Raw\kcsapi_remodel_slot.cs" />
     <Compile Include="Models\Raw\kcsapi_hensei_combined.cs" />
     <Compile Include="Models\Raw\kcsapi_combined_battle_battleresult.cs" />

--- a/Grabacr07.KanColleWrapper/Master.cs
+++ b/Grabacr07.KanColleWrapper/Master.cs
@@ -41,6 +41,16 @@ namespace Grabacr07.KanColleWrapper
 		/// </summary>
 		public MasterTable<Mission> Missions { get; private set; }
 
+		/// <summary>
+		/// すべての海域の定義を取得します。
+		/// </summary>
+		public MasterTable<MapArea> MapAreas { get; private set; }
+
+		/// <summary>
+		/// すべてのマップの定義を取得します。
+		/// </summary>
+		public MasterTable<MapInfo> MapInfos { get; private set; } 
+
 
 		internal Master(kcsapi_start2 start2)
 		{
@@ -49,6 +59,8 @@ namespace Grabacr07.KanColleWrapper
 			this.SlotItems = new MasterTable<SlotItemInfo>(start2.api_mst_slotitem.Select(x => new SlotItemInfo(x)));
 			this.UseItems = new MasterTable<UseItemInfo>(start2.api_mst_useitem.Select(x => new UseItemInfo(x)));
 			this.Missions = new MasterTable<Mission>(start2.api_mst_mission.Select(x => new Mission(x)));
+			this.MapAreas = new MasterTable<MapArea>(start2.api_mst_maparea.Select(x => new MapArea(x)));
+			this.MapInfos = new MasterTable<MapInfo>(start2.api_mst_mapinfo.Select(x => new MapInfo(x, this.MapAreas)));
 		}
 	}
 }

--- a/Grabacr07.KanColleWrapper/Models/MapArea.cs
+++ b/Grabacr07.KanColleWrapper/Models/MapArea.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Grabacr07.KanColleWrapper.Models.Raw;
+
+namespace Grabacr07.KanColleWrapper.Models
+{
+	public class MapArea : RawDataWrapper<kcsapi_mst_maparea>, IIdentifiable
+	{
+		public int Id { get; private set; }
+
+		public string Name { get; private set; }
+
+		public MapArea(kcsapi_mst_maparea maparea)
+			: base(maparea)
+		{
+			this.Id = maparea.api_id;
+			this.Name = maparea.api_name;
+		}
+
+		#region static members
+
+		private static MapArea dummy = new MapArea(new kcsapi_mst_maparea()
+		{
+			api_id = 0,
+			api_name = "？？？",
+		});
+
+		public static MapArea Dummy
+		{
+			get { return dummy; }
+		}
+
+		#endregion
+	}
+}

--- a/Grabacr07.KanColleWrapper/Models/MapInfo.cs
+++ b/Grabacr07.KanColleWrapper/Models/MapInfo.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Grabacr07.KanColleWrapper.Models.Raw;
+
+namespace Grabacr07.KanColleWrapper.Models
+{
+	public class MapInfo : RawDataWrapper<kcsapi_mst_mapinfo>, IIdentifiable
+	{
+		public int Id { get; private set; }
+
+		public string Name { get; private set; }
+
+		public int MapAreaId { get; private set; }
+
+		public MapArea MapArea { get; private set; }
+
+		public int IdInEachMapArea { get; private set; }
+
+		public int Level { get; private set; }
+
+		public string OperationName { get; private set; }
+
+		public string OperationSummary { get; private set; }
+
+		public int RequiredDefeatCount { get; private set; }
+
+		public MapInfo(kcsapi_mst_mapinfo mapinfo, MasterTable<MapArea> mapAreas)
+			: base(mapinfo)
+		{
+			this.Id = mapinfo.api_id;
+			this.Name = mapinfo.api_name;
+			this.MapAreaId = mapinfo.api_maparea_id;
+			this.MapArea = mapAreas[mapinfo.api_maparea_id] ?? MapArea.Dummy;
+			this.IdInEachMapArea = mapinfo.api_no;
+			this.Level = mapinfo.api_level;
+			this.OperationName = mapinfo.api_opetext;
+			this.OperationSummary = mapinfo.api_infotext;
+			this.RequiredDefeatCount = mapinfo.api_required_defeat_count ?? 1;
+		}
+
+		#region static members
+
+		private static MapInfo dummy = new MapInfo(new kcsapi_mst_mapinfo()
+		{
+			api_id = 0,
+			api_name = "？？？",
+			api_maparea_id = 0,
+			api_no = 0,
+			api_level = 0,
+		}, new MasterTable<MapArea>());
+
+		public static MapInfo Dummy
+		{
+			get { return dummy; }
+		}
+
+		#endregion
+	}
+}

--- a/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_maparea.cs
+++ b/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_maparea.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Grabacr07.KanColleWrapper.Models.Raw
+{
+	public class kcsapi_mst_maparea
+	{
+		public int api_id { get; set; }
+		public string api_name { get; set; }
+		public int api_type { get; set; }
+	}
+}

--- a/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_mapinfo.cs
+++ b/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_mapinfo.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Grabacr07.KanColleWrapper.Models.Raw
+{
+	public class kcsapi_mst_mapinfo
+	{
+		public int api_id { get; set; }
+		public int api_maparea_id { get; set; }
+		public int api_no { get; set; }
+		public string api_name { get; set; }
+		public int api_level { get; set; }
+		public string api_opetext { get; set; }
+		public string api_infotext { get; set; }
+		public int[] api_item { get; set; }
+		public int? api_max_maphp { get; set; }
+		public int? api_required_defeat_count { get; set; }
+		public int[] api_sally_flag { get; set; }
+	}
+}

--- a/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_start2.cs
+++ b/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_start2.cs
@@ -14,6 +14,8 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 		public kcsapi_mst_useitem[] api_mst_useitem { get; set; }
 		public kcsapi_mst_stype[] api_mst_stype { get; set; }
 		public kcsapi_mst_slotitem_equiptype[] api_mst_slotitem_equiptype { get; set; }
+		public kcsapi_mst_maparea[] api_mst_maparea { get; set; }
+		public kcsapi_mst_mapinfo[] api_mst_mapinfo { get; set; }
 
 		// ↓ とりあえずそのまま。
 
@@ -23,8 +25,6 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 		public Api_Mst_Furnituregraph[] api_mst_furnituregraph { get; set; }
 		public Api_Mst_Payitem[] api_mst_payitem { get; set; }
 		public Api_Mst_Item_Shop api_mst_item_shop { get; set; }
-		public Api_Mst_Maparea[] api_mst_maparea { get; set; }
-		public Api_Mst_Mapinfo[] api_mst_mapinfo { get; set; }
 		public Api_Mst_Mapbgm[] api_mst_mapbgm { get; set; }
 		public Api_Mst_Mapcell[] api_mst_mapcell { get; set; }
 		public kcsapi_mission[] api_mst_mission { get; set; }


### PR DESCRIPTION
EventMapHpViewerプラグイン用に必要になったので追加しました。

* プラグインはツールタブを開いた時にロードされるため、マスタデータは解析済みのものしか取得できないため
    * 逆に起動後流れてくるデータは自前でもなんとかなる
* 本体には3.7b時点でも実装されていない部分なので、Confrictはしないかと

可能な限りマスタデータは追加した方が良いのかもしれませんが、刺し身たんぽぽ的作業が辛くて……