### PR TITLE
Improve Logger logic and add a new Log Viewer window

### DIFF
--- a/Grabacr07.KanColleViewer/KanColleViewer.csproj
+++ b/Grabacr07.KanColleViewer/KanColleViewer.csproj
@@ -146,8 +146,10 @@
     <Compile Include="Models\Settings.cs" />
     <Compile Include="Models\SupportedImageFormat.cs" />
     <Compile Include="Models\Volume.cs" />
+    <Compile Include="ViewModels\Catalogs\LogItemCollection.cs" />
     <Compile Include="ViewModels\Catalogs\ShipCatalogFilter.cs" />
     <Compile Include="ViewModels\Catalogs\ShipViewModel.cs" />
+    <Compile Include="ViewModels\Catalogs\DropLogCatalogViewModel.cs" />
     <Compile Include="ViewModels\Catalogs\SlotItemCatalogViewModel.cs" />
     <Compile Include="ViewModels\Catalogs\SlotItemCounter.cs" />
     <Compile Include="ViewModels\Catalogs\ShipCatalogSortWorker.cs" />
@@ -200,6 +202,9 @@
     <Compile Include="Views\Behaviors\ScreenshotAction.cs" />
     <Compile Include="Views\Behaviors\SetStyleSheetBehavior.cs" />
     <Compile Include="Views\Behaviors\SetWindowLocationAction.cs" />
+    <Compile Include="Views\Catalogs\DropLogCatalogWindow.xaml.cs">
+      <DependentUpon>DropLogCatalogWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\Contents\StateDetailIndicator.xaml.cs">
       <DependentUpon>StateDetailIndicator.xaml</DependentUpon>
     </Compile>
@@ -210,6 +215,7 @@
       <DependentUpon>Tools.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\Controls\KanColleHost.cs" />
+    <Compile Include="Views\Controls\LogListView.cs" />
     <Compile Include="Views\Controls\WebBrowserHelper.cs" />
     <Compile Include="Views\Behaviors\ZoomAction.cs" />
     <Compile Include="Views\BrowserNavigator.xaml.cs">
@@ -382,6 +388,10 @@
     <Page Include="Views\Catalogs\ShipCatalogWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\Catalogs\DropLogCatalogWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\Catalogs\SlotItemCatalogWindow.xaml">
       <SubType>Designer</SubType>

--- a/Grabacr07.KanColleViewer/ViewModels/Catalogs/DropLogCatalogViewModel.cs
+++ b/Grabacr07.KanColleViewer/ViewModels/Catalogs/DropLogCatalogViewModel.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using Grabacr07.KanColleWrapper;
+using Grabacr07.KanColleWrapper.Models;
+using Livet;
+
+namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
+{
+	public class DropLogCatalogViewModel : WindowViewModel
+    {
+        #region LogCollection 変更通知プロパティ
+
+        private LogItemCollection _logCollection;
+
+        public LogItemCollection LogCollection
+		{
+            get { return this._logCollection; }
+			set
+			{
+                if (this._logCollection != value)
+				{
+                    this._logCollection = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+
+		#endregion
+
+        #region IsReloading 変更通知プロパティ
+
+        private bool _IsReloading;
+
+        public bool IsReloading
+        {
+            get { return this._IsReloading; }
+            set
+            {
+                if (this._IsReloading != value)
+                {
+                    this._IsReloading = value;
+                    this.RaisePropertyChanged();
+                }
+            }
+        }
+
+        #endregion
+
+        #region SelectorBuildItem 変更通知プロパティ
+
+        private bool _selectorBuildItem;
+
+        public bool SelectorBuildItem
+        {
+            get { return this._selectorBuildItem; }
+            set
+            {
+                if (this._selectorBuildItem != value)
+                {
+                    this._selectorBuildItem = value;
+                    if (value)
+                        this.CurrentLogType = Logger.LogType.BuildItem;
+                    this.RaisePropertyChanged();
+                }
+            }
+        }
+
+        #endregion
+
+        #region SelectorBuildShip 変更通知プロパティ
+
+        private bool _selectorBuildShip;
+
+        public bool SelectorBuildShip
+        {
+            get { return this._selectorBuildShip; }
+            set
+            {
+                if (this._selectorBuildShip != value)
+                {
+                    this._selectorBuildShip = value;
+                    if (value)
+                        this.CurrentLogType = Logger.LogType.BuildShip;
+                    this.RaisePropertyChanged();
+                }
+            }
+        }
+
+        #endregion
+
+        #region SelectorShipDrop 変更通知プロパティ
+
+        private bool _selectorShipDrop = true;
+
+        public bool SelectorShipDrop
+        {
+            get { return this._selectorShipDrop; }
+            set
+            {
+                if (this._selectorShipDrop != value)
+                {
+                    this._selectorShipDrop = value;
+                    if (value)
+                        this.CurrentLogType = Logger.LogType.ShipDrop;
+                    this.RaisePropertyChanged();
+                }
+            }
+        }
+
+        #endregion
+
+        #region CurrentLogType
+
+	    private Logger.LogType _currentLogType;
+
+        private Logger.LogType CurrentLogType
+	    {
+            get { return this._currentLogType; }
+	        set
+            {
+                if (this._currentLogType != value)
+                {
+                    this._currentLogType = value;
+
+                    _watcher.Filter = Logger.LogParameters[value].FileName;
+
+                    this.Update();
+                }
+	        }
+	    }
+
+        #endregion
+
+	    private FileSystemWatcher _watcher;
+
+        public DropLogCatalogViewModel()
+		{
+            this.Title = "ログ一覧";
+
+            this.SelectorShipDrop = true;
+            this._currentLogType = Logger.LogType.ShipDrop;
+
+			this.Update();
+
+            try
+            {
+
+                this._watcher = new FileSystemWatcher(Logger.LogFolder)
+                                {
+                                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime | NotifyFilters.FileName,
+                                    Filter = Logger.LogParameters[Logger.LogType.ShipDrop].FileName,
+                                    EnableRaisingEvents = true
+                                };
+
+                this._watcher.Changed += (sender, e) => { this.Update(); };
+                this._watcher.Created += (sender, e) => { this.Update(); };
+                this._watcher.Deleted += (sender, e) => { this.Update(); };
+                this._watcher.Renamed += (sender, e) => { this.Update(); };
+            }
+            catch (Exception)
+            {
+                if (this._watcher != null)
+                    this._watcher.EnableRaisingEvents = false;
+            }
+		}
+
+		public async void Update()
+		{
+		    this.IsReloading = true;
+            this.LogCollection = await this.UpdateCore();
+		    this.IsReloading = false;
+		}
+
+        private Task<LogItemCollection> UpdateCore()
+        {
+            LogItemCollection items = new LogItemCollection();
+
+            return Task.Factory.StartNew(() =>
+                                         {
+                                             try
+                                             {
+                                                 string file = Path.Combine(Logger.LogFolder,
+                                                                            Logger.LogParameters[this.CurrentLogType].FileName);
+                                                 if (!File.Exists(file))
+                                                     return items;
+
+                                                 IEnumerable<string> lines = File.ReadLines(file);
+
+                                                 lines.Take(1).First().Split(',').ForEach(col => items.Columns.Add(col));
+
+                                                 lines.Skip(1).Reverse().Take(200).ForEach(line =>
+                                                                                           {
+                                                                                               string[] elements = line.Split(',');
+
+                                                                                               if (elements.Length < 5)
+                                                                                                   return;
+
+                                                                                               items.Rows.Add(elements
+                                                                                                                  .Take(items.Columns.Count)
+                                                                                                                  .ToArray());
+                                                                                           });
+
+                                                 return items;
+                                             }
+                                             catch (Exception)
+                                             {
+                                                 return items;
+                                             }
+                                         });
+	    }
+	}
+}

--- a/Grabacr07.KanColleViewer/ViewModels/Catalogs/LogItemCollection.cs
+++ b/Grabacr07.KanColleViewer/ViewModels/Catalogs/LogItemCollection.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
+{
+    public class LogItemCollection : IEnumerable
+    {
+        public List<string> Columns = new List<string>();
+        public List<string[]> Rows = new List<string[]>();
+
+        public IEnumerator GetEnumerator()
+        {
+            return this.Rows.GetEnumerator();
+        }
+    }
+}

--- a/Grabacr07.KanColleViewer/ViewModels/Contents/OverviewViewModel.cs
+++ b/Grabacr07.KanColleViewer/ViewModels/Contents/OverviewViewModel.cs
@@ -64,5 +64,12 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 			var message = new TransitionMessage(catalog, "Show/SlotItemCatalogWindow");
 			this.Messenger.RaiseAsync(message);
 		}
+
+		public void ShowDropLogCatalog()
+		{
+			var catalog = new DropLogCatalogViewModel();
+			var message = new TransitionMessage(catalog, "Show/DropLogCatalogWindow");
+			this.Messenger.RaiseAsync(message);
+		}
 	}
 }

--- a/Grabacr07.KanColleViewer/Views/Catalogs/DropLogCatalogWindow.xaml
+++ b/Grabacr07.KanColleViewer/Views/Catalogs/DropLogCatalogWindow.xaml
@@ -1,0 +1,175 @@
+﻿<metro:MetroWindow x:Class="Grabacr07.KanColleViewer.Views.Catalogs.DropLogCatalogWindow"
+				   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+				   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				   xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+				   xmlns:ei="http://schemas.microsoft.com/expression/2010/interactions"
+				   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+				   xmlns:ed="http://schemas.microsoft.com/expression/2010/drawing"
+				   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+				   xmlns:livet="http://schemas.livet-mvvm.net/2011/wpf"
+				   xmlns:metro="http://schemes.grabacr.net/winfx/2014/controls"
+				   xmlns:metro2="clr-namespace:Grabacr07.Desktop.Metro.Controls;assembly=Desktop.Metro"
+				   xmlns:properties="clr-namespace:Grabacr07.KanColleViewer.Properties"
+				   xmlns:views="clr-namespace:Grabacr07.KanColleViewer.Views"
+				   xmlns:viewModels="clr-namespace:Grabacr07.KanColleViewer.ViewModels.Catalogs"
+				   xmlns:behaviors="clr-namespace:Grabacr07.KanColleViewer.Views.Behaviors"
+				   xmlns:controls="clr-namespace:Grabacr07.KanColleViewer.Views.Controls"
+				   xmlns:contents="clr-namespace:Grabacr07.KanColleViewer.Views.Contents"
+				   xmlns:catalogs="clr-namespace:Grabacr07.KanColleViewer.Views.Catalogs"
+				   x:Name="GlowMetroWindow"
+				   mc:Ignorable="d"
+				   d:DataContext="{d:DesignInstance viewModels:DropLogCatalogViewModel}"
+				   Title="{Binding Title}"
+				   Width="700"
+				   Height="800"
+				   FontSize="12"
+				   Background="{DynamicResource ThemeBrushKey}"
+				   Foreground="{DynamicResource ActiveForegroundBrushKey}"
+				   IsRestoringWindowPlacement="True"
+				   UseLayoutRounding="True"
+				   TextOptions.TextFormattingMode="Display">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<!-- #region CaptionBar -->
+		<Border metro:MetroWindow.IsCaptionBar="True"
+				Panel.ZIndex="100">
+
+			<Grid>
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition />
+					<ColumnDefinition Width="Auto" />
+				</Grid.ColumnDefinitions>
+
+				<controls:AppIcon Width="36"
+								  Height="36"
+								  Background="Transparent"
+								  AnchorVisibility="Collapsed"
+								  BandVisibility="Collapsed" />
+
+				<TextBlock Grid.Column="1"
+						   Text="{Binding Title}"
+						   Style="{DynamicResource CaptionTextStyleKey}"
+						   Margin="2,0,8,0" />
+
+				<metro:SystemButtons Grid.Column="2"
+									 HorizontalAlignment="Right"
+									 VerticalAlignment="Top" />
+			</Grid>
+		</Border>
+		<!-- #endregion -->
+
+        <DockPanel Grid.Row="1">
+            <Grid DockPanel.Dock="Top"  DataContext="{Binding .}"
+					Margin="8,8,8,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="10" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBlock Margin="5,5,5,5" HorizontalAlignment="Right">
+										<Run Text="ログ :" />
+                </TextBlock>
+                <WrapPanel Grid.Column="2">
+                    <RadioButton Content="出撃ドロップ" IsChecked="{Binding SelectorShipDrop, Mode=TwoWay}" Margin="5,5,5,5"/>
+                    <RadioButton Content="艦船建造" IsChecked="{Binding SelectorBuildShip, Mode=TwoWay}" Margin="5,5,5,5"/>
+                    <RadioButton Content="装備開発" IsChecked="{Binding SelectorBuildItem, Mode=TwoWay}" Margin="5,5,5,5"/>
+                </WrapPanel>
+            </Grid>
+
+			<Border BorderBrush="{DynamicResource BorderBrushKey}"
+					BorderThickness="1"
+					Margin="8">
+                <ListView controls:LogListView.LogSource="{Binding LogCollection}"
+						  ItemContainerStyle="{DynamicResource GridViewItemContainerStyleKey}"
+						  ScrollViewer.PanningMode="Both">
+                    <ListView.Resources>
+                        <Style TargetType="{x:Type TextBlock}"
+							   BasedOn="{StaticResource DefaultTextStyleKey}">
+                            <Setter Property="Margin"
+									Value="5,4" />
+                        </Style>
+                        <Style TargetType="{x:Type GridViewColumnHeader}">
+                            <Setter Property="OverridesDefaultStyle"
+									Value="True" />
+                            <Setter Property="BorderThickness"
+									Value="0,0,0,1" />
+                            <Setter Property="BorderBrush"
+									Value="{DynamicResource BorderBrushKey}" />
+                            <Setter Property="Background"
+									Value="{DynamicResource BackgroundBrushKey}" />
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type GridViewColumnHeader}">
+                                        <Grid>
+                                            <Border BorderThickness="{TemplateBinding BorderThickness}"
+													BorderBrush="{TemplateBinding BorderBrush}"
+													Background="{TemplateBinding Background}">
+                                                <ContentPresenter Margin="{TemplateBinding Padding}" />
+                                            </Border>
+                                            <Thumb x:Name="PART_HeaderGripper"
+												   HorizontalAlignment="Right"
+												   BorderBrush="{TemplateBinding BorderBrush}"
+												   Margin="0,0,-6,0">
+                                                <Thumb.Template>
+                                                    <ControlTemplate TargetType="{x:Type Thumb}">
+                                                        <Border Background="Transparent"
+																Width="13">
+                                                            <Rectangle Width="1"
+																	   Stroke="{TemplateBinding BorderBrush}" />
+                                                        </Border>
+                                                    </ControlTemplate>
+                                                </Thumb.Template>
+                                            </Thumb>
+                                        </Grid>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </ListView.Resources>
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn Width="120">
+                                <GridViewColumn.Header>
+                                    <TextBlock>
+                                        PlaceHolder
+                                    </TextBlock>
+                                </GridViewColumn.Header>
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate DataType="{x:Type viewModels:LogItemCollection}">
+                                        <TextBlock Margin="0,4">
+											<Run Text="Placeholder"
+												 Foreground="{DynamicResource ActiveForegroundBrushKey}" />
+                                        </TextBlock>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+			</Border>
+		</DockPanel>
+
+		<Border Grid.Row="1"
+				Background="{DynamicResource ThemeBrushKey}"
+				BorderBrush="{DynamicResource BorderBrushKey}"
+				BorderThickness="1"
+				Opacity="0.75"
+				Margin="8,0,8,8"
+				Padding="20"
+				Visibility="{Binding IsReloading, Converter={StaticResource BooleanToVisibilityConverter}}"
+				d:IsHidden="True">
+			<TextBlock Text="一覧を生成しています..."
+					   Style="{DynamicResource EmphaticTextStyleKey}"
+					   FontSize="16"
+					   Background="{DynamicResource ThemeBrushKey}"
+					   HorizontalAlignment="Center" />
+		</Border>
+
+	</Grid>
+</metro:MetroWindow>

--- a/Grabacr07.KanColleViewer/Views/Catalogs/DropLogCatalogWindow.xaml.cs
+++ b/Grabacr07.KanColleViewer/Views/Catalogs/DropLogCatalogWindow.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Grabacr07.KanColleViewer.Views.Catalogs
+{
+	/// <summary>
+	/// 装備一覧ウィンドウを表します。
+	/// </summary>
+	partial class DropLogCatalogWindow
+	{
+        public DropLogCatalogWindow()
+		{
+			this.InitializeComponent();
+
+			MainWindow.Current.Closed += (sender, args) => this.Close();
+		}
+	}
+}

--- a/Grabacr07.KanColleViewer/Views/Contents/Overview.xaml
+++ b/Grabacr07.KanColleViewer/Views/Contents/Overview.xaml
@@ -90,6 +90,12 @@
 													  WindowType="catalogs:SlotItemCatalogWindow"
 													  IsOwned="False" />
 		</livet:InteractionMessageTrigger>
+		<livet:InteractionMessageTrigger Messenger="{Binding Messenger}"
+										 MessageKey="Show/DropLogCatalogWindow">
+			<livet:TransitionInteractionMessageAction Mode="NewOrActive"
+													  WindowType="catalogs:DropLogCatalogWindow"
+													  IsOwned="False" />
+		</livet:InteractionMessageTrigger>
 	</i:Interaction.Triggers>
 
 
@@ -313,7 +319,12 @@
 
 						<metro2:CallMethodButton Content="装備一覧"
 												 Padding="12,8"
+												 Margin="0,0,0,8"
 												 MethodName="ShowSlotItemCatalog" />
+
+						<metro2:CallMethodButton Content="ログ一覧"
+												 Padding="12,8"
+												 MethodName="ShowDropLogCatalog" />
 					</StackPanel>
 				</Border>
 

--- a/Grabacr07.KanColleViewer/Views/Controls/LogListView.cs
+++ b/Grabacr07.KanColleViewer/Views/Controls/LogListView.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using Grabacr07.KanColleViewer.ViewModels.Catalogs;
+
+namespace Grabacr07.KanColleViewer.Views.Controls
+{
+    public class LogListView
+    {
+        public static readonly DependencyProperty LogSourceProperty =
+            DependencyProperty.RegisterAttached("LogSource",
+                                                typeof(LogItemCollection), typeof(LogListView),
+                                                new FrameworkPropertyMetadata(null, OnLogSourceChanged));
+
+        public static LogItemCollection GetLogSource(DependencyObject d)
+        {
+            return (LogItemCollection)d.GetValue(LogSourceProperty);
+        }
+
+        public static void SetLogSource(DependencyObject d, LogItemCollection value)
+        {
+            d.SetValue(LogSourceProperty, value);
+        }
+
+        private static void OnLogSourceChanged(DependencyObject d,
+            DependencyPropertyChangedEventArgs e)
+        {
+            ListView listView = d as ListView;
+            LogItemCollection collection = e.NewValue as LogItemCollection;
+
+            listView.ItemsSource = collection;
+            GridView gridView = listView.View as GridView;
+            int count = 0;
+            gridView.Columns.Clear();
+            foreach (var col in collection.Columns)
+            {
+                var cell = new FrameworkElementFactory(typeof(TextBlock));
+                cell.SetBinding(TextBlock.TextProperty, new Binding(string.Format("[{0}]", count++)));
+                cell.SetValue(FrameworkElement.MarginProperty, new Thickness(0, 4, 0, 4));
+
+                gridView.Columns.Add(
+                                     new GridViewColumn
+                                     {
+                                         Header = new TextBlock { Text = col, Margin = new Thickness(5, 4, 5, 4) },
+                                         CellTemplate = new DataTemplate
+                                                        {
+                                                            DataType = typeof(LogItemCollection),
+                                                            VisualTree = cell,
+                                                        }
+                                     });
+            }
+        }
+    }
+}

--- a/Grabacr07.KanColleViewer/Views/Settings/Others.xaml
+++ b/Grabacr07.KanColleViewer/Views/Settings/Others.xaml
@@ -124,14 +124,13 @@
 		<Rectangle Height="1"
 				   Style="{DynamicResource SeparatorRectangleStyleKey}" />
 
-		<!--<TextBlock Text="{Binding Source={x:Static properties:Resources.Settings_Logging}, Mode=OneWay}"
-				   Style="{DynamicResource HeaderTextBlockStyleKey}"
+		<TextBlock Text="{Binding Source={x:Static properties:Resources.Settings_Logging}, Mode=OneWay}"
+				   Style="{DynamicResource SettingsHeaderTextStyleKey}"
 				   Margin="0,10" />
 		<CheckBox Content="{Binding Source={x:Static properties:Resources.Settings_Logging_Enable}, Mode=OneWay}"
 				  IsChecked="{Binding EnableLogging}"
-				  IsEnabled="False"
 				  Height="17"
-				  Margin="15,0,0,10" />-->
+				  Margin="15,0,0,10" />
 
 	</StackPanel>
 </UserControl>

--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -60,6 +60,8 @@ namespace Grabacr07.KanColleWrapper
 
 		internal Logger(KanColleProxy proxy)
 		{
+			this.EnableLogging = KanColleClient.Current.Settings.EnableLogging;
+
 			this.shipmats = new int[5];
 
 			proxy.api_req_kousyou_createitem.TryParse<kcsapi_createitem>().Subscribe(x => this.CreateItem(x.Data, x.Request));

--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -149,7 +149,7 @@ namespace Grabacr07.KanColleWrapper
 
 		private void Log(LogType type, params object[] args)
 		{
-			//if (!this.EnableLogging) return;
+			if (!this.EnableLogging) return;
 
 			string logPath = this.CreateLogFile(type);
 

--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -15,35 +15,77 @@ namespace Grabacr07.KanColleWrapper
 {
 	public class Logger : NotificationObject
 	{
-		public bool EnableLogging { get; set; }
-
 		private bool waitingForShip;
 		private int dockid;
 		private readonly int[] shipmats;
 
-		private enum LogType
+		public bool EnableLogging { get; set; }
+
+		// ReSharper disable once AssignNullToNotNullAttribute
+		public static string LogFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Logs");
+
+	    public enum LogType
 		{
 			BuildItem,
 			BuildShip,
 			ShipDrop
 		};
 
+	    public struct LogTypeInfo
+		{
+			public string Parameters;
+            public string FileName;
+
+            public LogTypeInfo(string parameters, string fileName)
+			{
+				this.Parameters = parameters;
+				this.FileName = fileName;
+			}
+		}
+
+		public static Dictionary<LogType, LogTypeInfo> LogParameters =
+			new Dictionary<LogType, LogTypeInfo>
+			{
+				{
+					LogType.BuildItem, new LogTypeInfo("日付,結果,秘書艦,秘書艦 Lv,秘書艦艦種,燃料,弾薬,鋼材,ボーキサイト",
+													   "BuildItemLog.csv")
+				},
+				{
+					LogType.BuildShip, new LogTypeInfo("日付,結果,秘書艦,秘書艦 Lv,秘書艦艦種,燃料,弾薬,鋼材,ボーキサイト,開発資材",
+													   "BuildShipLog.csv")
+				},
+				{ LogType.ShipDrop, new LogTypeInfo("日付,結果,海域,敵艦隊,ランク", "ShipDropLog.csv") }
+			};
+
 		internal Logger(KanColleProxy proxy)
 		{
 			this.shipmats = new int[5];
 
-			// ちょっと考えなおす
-			//proxy.api_req_kousyou_createitem.TryParse<kcsapi_createitem>().Subscribe(x => this.CreateItem(x.Data, x.Request));
-			//proxy.api_req_kousyou_createship.TryParse<kcsapi_createship>().Subscribe(x => this.CreateShip(x.Request));
-			//proxy.api_get_member_kdock.TryParse<kcsapi_kdock[]>().Subscribe(x => this.KDock(x.Data));
-			//proxy.api_req_sortie_battleresult.TryParse<kcsapi_battleresult>().Subscribe(x => this.BattleResult(x.Data));
+			proxy.api_req_kousyou_createitem.TryParse<kcsapi_createitem>().Subscribe(x => this.CreateItem(x.Data, x.Request));
+			proxy.api_req_kousyou_createship.TryParse<kcsapi_createship>().Subscribe(x => this.CreateShip(x.Request));
+			proxy.api_get_member_kdock.TryParse<kcsapi_kdock[]>().Subscribe(x => this.KDock(x.Data));
+			proxy.api_req_sortie_battleresult.TryParse<kcsapi_battleresult>().Subscribe(x => this.BattleResult(x.Data));
 		}
 
 		private void CreateItem(kcsapi_createitem item, NameValueCollection req)
 		{
-			this.Log(LogType.BuildItem, "{0},{1},{2},{3},{4},{5},{6}", item.api_create_flag == 1 ? KanColleClient.Current.Master.SlotItems[item.api_slotitem_id].Name : "NA",
-				KanColleClient.Current.Homeport.Organization.Fleets[1].Ships[0].Info.ShipType.Name,
-				req["api_item1"], req["api_item2"], req["api_item3"], req["api_item4"], DateTime.Now.ToString("M/d/yyyy H:mm"));
+			try
+			{
+				this.Log(LogType.BuildItem,
+						 item.api_create_flag == 1 ? KanColleClient.Current.Master.SlotItems[item.api_slot_item.api_slotitem_id].Name : "NA", //Result
+						 KanColleClient.Current.Homeport.Organization.Fleets[1].Ships[0].Info.Name, //Secretary
+						 KanColleClient.Current.Homeport.Organization.Fleets[1].Ships[0].Level, //Secretary Level
+						 KanColleClient.Current.Homeport.Organization.Fleets[1].Ships[0].Info.ShipType.Name, //Secretary Type
+						 req["api_item1"], //Fuel
+						 req["api_item2"], //Ammo
+						 req["api_item3"], //Steel
+						 req["api_item4"] //Bauxite
+					);
+			}
+			catch (Exception)
+			{
+				// ignored
+			}
 		}
 
 		private void CreateShip(NameValueCollection req)
@@ -59,71 +101,88 @@ namespace Grabacr07.KanColleWrapper
 
 		private void KDock(kcsapi_kdock[] docks)
 		{
-			foreach (var dock in docks.Where(dock => this.waitingForShip && dock.api_id == this.dockid))
+			try
 			{
-				this.Log(LogType.BuildShip, "{0},{1},{2},{3},{4},{5},{6}", KanColleClient.Current.Master.Ships[dock.api_created_ship_id].Name, this.shipmats[0], this.shipmats[1], this.shipmats[2], this.shipmats[3], this.shipmats[4], DateTime.Now.ToString("M/d/yyyy H:mm"));
+				foreach (var dock in docks.Where(dock => this.waitingForShip && dock.api_id == this.dockid))
+				{
+					this.Log(LogType.BuildShip,
+							 KanColleClient.Current.Master.Ships[dock.api_created_ship_id].Name, //Result
+							 KanColleClient.Current.Homeport.Organization.Fleets[1].Ships[0].Info.Name, //Secretary
+							 KanColleClient.Current.Homeport.Organization.Fleets[1].Ships[0].Level, //Secretary Level
+							 KanColleClient.Current.Homeport.Organization.Fleets[1].Ships[0].Info.ShipType.Name, //Secretary Type
+							 this.shipmats[0], //Fuel
+							 this.shipmats[1], //Ammo
+							 this.shipmats[2], //Steel
+							 this.shipmats[3], //Bauxite
+							 this.shipmats[4] //Materials
+						);
+
+					this.waitingForShip = false;
+				}
+			}
+			catch (Exception)
+			{
 				this.waitingForShip = false;
 			}
 		}
 
 		private void BattleResult(kcsapi_battleresult br)
 		{
-			if (br.api_get_ship == null)
-				return;
+			try
+			{
+				if (br.api_get_ship == null)
+					return;
 
-			this.Log(LogType.ShipDrop, "{0},{1},{2},{3},{4}", br.api_get_ship.api_ship_name, br.api_quest_name, br.api_enemy_info.api_deck_name, br.api_win_rank, DateTime.Now.ToString("M/d/yyyy H:mm"));
+				this.Log(LogType.ShipDrop,
+						 br.api_get_ship.api_ship_name, //Result
+						 br.api_quest_name, //Operation
+						 br.api_enemy_info.api_deck_name, //Enemy Fleet
+						 br.api_win_rank //Rank
+					);
+			}
+			catch (Exception)
+			{
+				// ignored
+			}
 		}
 
-		private void Log(LogType type, string format, params object[] args)
+		private void Log(LogType type, params object[] args)
 		{
-			if (!this.EnableLogging) return;
+			//if (!this.EnableLogging) return;
 
-			var mainFolder = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+			string logPath = this.CreateLogFile(type);
 
-			switch (type)
+			if (String.IsNullOrEmpty(logPath))
+				return;
+
+			using (var w = File.AppendText(logPath))
 			{
-				case LogType.BuildItem:
-					if (!File.Exists(mainFolder + "\\ItemBuildLog.csv"))
-					{
-						using (var w = File.AppendText(mainFolder + "\\ItemBuildLog.csv"))
-						{
-							w.WriteLine("Result,Secretary,Fuel,Ammo,Steel,Bauxite,Date", args);
-						}
-					}
-					using (var w = File.AppendText(mainFolder + "\\ItemBuildLog.csv"))
-					{
-						w.WriteLine(format, args);
-					}
-					break;
+				w.Write(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + ",");
+				args.ForEach(arg => w.Write(arg + ","));
+                w.WriteLine();
+			}
+		}
 
-				case LogType.BuildShip:
-					if (!File.Exists(mainFolder + "\\ShipBuildLog.csv"))
-					{
-						using (var w = File.AppendText(mainFolder + "\\ShipBuildLog.csv"))
-						{
-							w.WriteLine("Result,Fuel,Ammo,Steel,Bauxite,# of Build Materials,Date", args);
-						}
-					}
-					using (var w = File.AppendText(mainFolder + "\\ShipBuildLog.csv"))
-					{
-						w.WriteLine(format, args);
-					}
-					break;
+		private string CreateLogFile(LogType type)
+		{
+			try
+			{
+				var info = LogParameters[type];
+				string fullPath = Path.Combine(LogFolder, info.FileName);
 
-				case LogType.ShipDrop:
-					if (!File.Exists(mainFolder + "\\DropLog.csv"))
-					{
-						using (var w = File.AppendText(mainFolder + "\\DropLog.csv"))
-						{
-							w.WriteLine("Result,Operation,Enemy Fleet,Rank,Date", args);
-						}
-					}
-					using (var w = File.AppendText(mainFolder + "\\DropLog.csv"))
-					{
-						w.WriteLine(format, args);
-					}
-					break;
+                if (!Directory.Exists(LogFolder))
+                    Directory.CreateDirectory(LogFolder);
+
+				if (!File.Exists(fullPath))
+					File.WriteAllText(fullPath, info.Parameters + Environment.NewLine, new UTF8Encoding(true));
+
+				return fullPath;
+			}
+			catch (Exception)
+			{
+				return null;
 			}
 		}
 	}
 }
+

--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Grabacr07.KanColleWrapper.Internal;
 using Grabacr07.KanColleWrapper.Models;


### PR DESCRIPTION
Hello,
I have finished improve on Logger logic that will log the following user operations:

* Ship Drop
* Build Item
* Build Ship

And also a new log viewer window can be accessed from the Overview page. For convenience, the content in the log viewer window can be updated while new lines have been written into log files.

Thanks :)

PS: The new log view looks like this:
![preview](https://cloud.githubusercontent.com/assets/1687847/6868240/3b258d18-d48a-11e4-9db1-dda70e4067a8.jpg)
