### PR TITLE
ColorIndicatorを少し改善してみました。

### DIFF
--- a/source/Grabacr07.KanColleViewer.Controls/Controls/ColorIndicator.cs
+++ b/source/Grabacr07.KanColleViewer.Controls/Controls/ColorIndicator.cs
@@ -41,6 +41,17 @@ namespace Grabacr07.KanColleViewer.Controls
 
 		#endregion
 
+		#region Columns 종속성 프로퍼티
+
+		public int Columns
+        {
+			get { return (int)this.GetValue(ColumnsProperty); }
+			set { this.SetValue(ColumnsProperty, value); }
+		}
+		public static readonly DependencyProperty ColumnsProperty =
+			DependencyProperty.Register(nameof(Columns), typeof(int), typeof(ColorIndicator), new UIPropertyMetadata(4));
+
+		#endregion
 
 		private void ChangeColor(LimitedValue value)
 		{

--- a/source/Grabacr07.KanColleViewer.Controls/Themes/Generic.ColorIndicator.xaml
+++ b/source/Grabacr07.KanColleViewer.Controls/Themes/Generic.ColorIndicator.xaml
@@ -3,19 +3,38 @@
 					xmlns:controls="clr-namespace:Grabacr07.KanColleViewer.Controls">
 
 	<Style TargetType="{x:Type controls:ColorIndicator}">
-		<Setter Property="Background"
-				Value="White" />
-		<Setter Property="HorizontalContentAlignment"
-				Value="Left" />
+        <Setter Property="Background" Value="#55D7D7E1" />
+		<Setter Property="HorizontalContentAlignment" Value="Left" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type controls:ColorIndicator}">
 					<Grid Background="{TemplateBinding Background}">
-						<Border x:Name="PART_Track" />
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        
+						<Border x:Name="PART_Track"
+                                Grid.RowSpan="4" />
 						<Border x:Name="PART_Indicator"
+                                Grid.RowSpan="4" 
 								Background="{TemplateBinding Foreground}"
 								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
-					</Grid>
+
+                        <UniformGrid x:Name="StepGrid" Columns="4">
+                            <Rectangle Grid.Column="0" HorizontalAlignment="Right" Width="1" Fill="{DynamicResource BackgroundBrushKey}" />
+                            <Rectangle Grid.Column="1" HorizontalAlignment="Right" Width="1" Fill="{DynamicResource BackgroundBrushKey}" />
+                            <Rectangle Grid.Column="2" HorizontalAlignment="Right" Width="1" Fill="{DynamicResource BackgroundBrushKey}" />
+                            <Rectangle x:Name="Fifth_Line" Grid.Column="3" HorizontalAlignment="Right" Width="1" Fill="{DynamicResource BackgroundBrushKey}" Visibility="Collapsed" />
+                        </UniformGrid>
+                    </Grid>
+                    
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Columns" Value="5">
+                            <Setter TargetName="Fifth_Line" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="StepGrid" Property="Columns" Value="5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/source/Grabacr07.KanColleViewer.Controls/Themes/Generic.ColorIndicator.xaml
+++ b/source/Grabacr07.KanColleViewer.Controls/Themes/Generic.ColorIndicator.xaml
@@ -22,10 +22,11 @@
 								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
 
                         <UniformGrid x:Name="StepGrid" Columns="4">
-                            <Rectangle Grid.Column="0" HorizontalAlignment="Right" Width="1" Fill="{DynamicResource BackgroundBrushKey}" />
-                            <Rectangle Grid.Column="1" HorizontalAlignment="Right" Width="1" Fill="{DynamicResource BackgroundBrushKey}" />
-                            <Rectangle Grid.Column="2" HorizontalAlignment="Right" Width="1" Fill="{DynamicResource BackgroundBrushKey}" />
-                            <Rectangle x:Name="Fifth_Line" Grid.Column="3" HorizontalAlignment="Right" Width="1" Fill="{DynamicResource BackgroundBrushKey}" Visibility="Collapsed" />
+                            <Rectangle Grid.Column="0" />
+                            <Rectangle Grid.Column="1" HorizontalAlignment="Left" Width="1" Fill="{DynamicResource BackgroundBrushKey}" />
+                            <Rectangle Grid.Column="2" HorizontalAlignment="Left" Width="1" Fill="{DynamicResource BackgroundBrushKey}" />
+                            <Rectangle Grid.Column="3" HorizontalAlignment="Left" Width="1" Fill="{DynamicResource BackgroundBrushKey}" />
+                            <Rectangle x:Name="Fifth_Line" Grid.Column="4" HorizontalAlignment="Left" Width="1" Fill="{DynamicResource BackgroundBrushKey}" Visibility="Collapsed" />
                         </UniformGrid>
                     </Grid>
                     

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -234,12 +234,14 @@
 														 Width="55"
 														 LimitedValue="{Binding Ship.Fuel, Mode=OneWay}"
 														 Height="6"
+                                                         Columns="5"
 														 Margin="0,6,0,7" />
 									<kcvc:ColorIndicator Grid.Column="6"
 														 Grid.Row="1"
 														 Width="55"
 														 LimitedValue="{Binding Ship.Bull, Mode=OneWay}"
 														 Height="6"
+                                                         Columns="5"
 														 VerticalAlignment="Top" />
 
 									<ItemsControl Grid.Column="7"

--- a/source/Grabacr07.KanColleViewer/Views/FleetWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/FleetWindow.xaml
@@ -299,6 +299,7 @@
 								<kcvc:ColorIndicator DockPanel.Dock="Top"
 													 LimitedValue="{Binding Fuel, Mode=OneWay}"
 													 Height="5"
+                                                     Columns="5"
 													 Margin="1,2,0,0" />
 								<Border />
 							</DockPanel>
@@ -326,6 +327,7 @@
 								<kcvc:ColorIndicator DockPanel.Dock="Top"
 													 LimitedValue="{Binding Bull, Mode=OneWay}"
 													 Height="5"
+                                                     Columns="5"
 													 Margin="1,2,0,0" />
 								<Border />
 							</DockPanel>


### PR DESCRIPTION
![085](https://cloud.githubusercontent.com/assets/20940566/17752561/6b68f014-6507-11e6-925a-6666b19e3511.PNG)

体力のカットラインである 25％,50%,75%の部分に目印を表示してみました。
燃料と弾薬は20%ずつ変化するので、Columnsプロパティを作ってから
Columnsが５になったら変わるようにしました。

-

![086](https://cloud.githubusercontent.com/assets/20940566/17752896/df2f549c-6508-11e6-8eaf-43d199ff4bf4.PNG)

それから、小破の色が黄色なのに背景が白なんで、よく見えなかったので背景の色を元の背景より少しだけ明るくした色にしました。