### PR TITLE
艦娘のコンディションに回復時間のTooltip追加です。

### DIFF
--- a/source/Grabacr07.KanColleViewer/KanColleViewer.csproj
+++ b/source/Grabacr07.KanColleViewer/KanColleViewer.csproj
@@ -82,6 +82,9 @@
       <HintPath>..\packages\LivetCask.1.3.1.0\lib\net45\Microsoft.Expression.Interactions.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.mshtml, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Nekoxy, Version=1.5.2.20, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Nekoxy.1.5.2.20\lib\net45\Nekoxy.dll</HintPath>
       <Private>True</Private>
@@ -168,6 +171,7 @@
     <Compile Include="Models\Settings\NetworkSettings.cs" />
     <Compile Include="Models\Settings\SettingsHost.cs" />
     <Compile Include="Models\Settings\WindowSettings.cs" />
+    <Compile Include="Models\ShipCondition.cs" />
     <Compile Include="Models\StatusService.cs" />
     <Compile Include="Models\Migration\_Settings.cs" />
     <Compile Include="Models\SupportedImageFormat.cs" />

--- a/source/Grabacr07.KanColleViewer/Models/ShipCondition.cs
+++ b/source/Grabacr07.KanColleViewer/Models/ShipCondition.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Grabacr07.KanColleWrapper;
+using Grabacr07.KanColleWrapper.Models;
+using Livet;
+
+namespace Grabacr07.KanColleViewer.Models
+{
+    public class ShipCondition : TimerNotifier
+    {
+        private DateTimeOffset? RejuvenateTime { get; }
+
+        private TimeSpan? _Remaining;
+        public TimeSpan? Remaining
+        {
+            get { return this._Remaining; }
+            private set
+            {
+                if (this._Remaining != value)
+                {
+                    this._Remaining = value;
+                    this.RaisePropertyChanged();
+                    this.RaisePropertyChanged("ConditionText");
+                }
+            }
+        }
+
+        public string ConditionText => this.Remaining.HasValue
+            ? $"{(int)this.Remaining.Value.TotalHours:D2}:{this.Remaining.Value.ToString(@"mm\:ss")}"
+            : "--:--:--";
+
+        public ShipCondition(Ship ship)
+        {
+            var condition = ship.Condition;
+            var rejuvenate = DateTimeOffset.Now; // 회복완료예상시각
+
+            while (condition < Math.Min(49, KanColleClient.Current.Settings.ReSortieCondition))
+            {
+                rejuvenate = rejuvenate.AddMinutes(3);
+                condition += 3;
+                if (condition > 49) condition = 49;
+            }
+            this.RejuvenateTime = rejuvenate <= DateTimeOffset.Now
+                ? (DateTimeOffset?)null
+                : rejuvenate;
+        }
+
+        protected override void Tick()
+        {
+            base.Tick();
+
+            if (this.RejuvenateTime.HasValue)
+            {
+                var remaining = this.RejuvenateTime.Value.Subtract(DateTimeOffset.Now);
+                if (remaining.Ticks < 0) remaining = TimeSpan.Zero;
+
+                this.Remaining = remaining;
+            }
+            else
+            {
+                this.Remaining = null;
+            }
+        }
+    }
+}

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/ShipViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/ShipViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Grabacr07.KanColleViewer.Models;
 using Grabacr07.KanColleWrapper.Models;
 using Livet;
 
@@ -10,10 +11,12 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 	public class ShipViewModel : ViewModel
 	{
 		public Ship Ship { get; }
+        public ShipCondition Condition { get; }
 
 		public ShipViewModel(Ship ship)
 		{
 			this.Ship = ship;
+            this.Condition = new ShipCondition(ship);
 		}
 	}
 }

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -221,30 +221,30 @@
 										</InlineUIContainer>
 										<Run Text="{Binding Ship.Condition, Mode=OneWay}"
 											 Style="{DynamicResource EmphaticTextElementStyleKey}" />
-                                        <LineBreak />
-                                        <Run Text="condition"
+										<LineBreak />
+										<Run Text="condition"
 											 FontSize="9" />
 
-                                        <TextBlock.ToolTip>
-                                            <TextBlock Style="{DynamicResource DefaultTextStyleKey}"
-                                                       Foreground="White">
-                                                <Run Text="피로회복까지:" />
-                                                <Run Text="{Binding Condition.ConditionText, Mode=OneWay}" />
-                                            </TextBlock>
-                                        </TextBlock.ToolTip>
+										<TextBlock.ToolTip>
+											<TextBlock Style="{DynamicResource DefaultTextStyleKey}"
+													   Foreground="White">
+												<Run Text="疲労回復まで:" />
+												<Run Text="{Binding Condition.ConditionText, Mode=OneWay}" />
+											</TextBlock>
+										</TextBlock.ToolTip>
 									</TextBlock>
 
-                                    <StackPanel Grid.Column="6"
-                                                Grid.RowSpan="2">
-                                        <kcvc:ColorIndicator Width="55"
-														     LimitedValue="{Binding Ship.Fuel, Mode=OneWay}"
-														     Height="6"
-														     Margin="0,6,0,7" />
-                                        <kcvc:ColorIndicator Width="55"
-														     LimitedValue="{Binding Ship.Bull, Mode=OneWay}"
-														     Height="6"
-														     VerticalAlignment="Top" />
-                                    </StackPanel>
+									<StackPanel Grid.Column="6"
+												Grid.RowSpan="2">
+										<kcvc:ColorIndicator Width="55"
+															 LimitedValue="{Binding Ship.Fuel, Mode=OneWay}"
+															 Height="6"
+															 Margin="0,6,0,7" />
+										<kcvc:ColorIndicator Width="55"
+															 LimitedValue="{Binding Ship.Bull, Mode=OneWay}"
+															 Height="6"
+															 VerticalAlignment="Top" />
+									</StackPanel>
 
 									<ItemsControl Grid.Column="7"
 												  Grid.Row="0"

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -214,18 +214,15 @@
 
 									<TextBlock Grid.Column="5"
 											   Grid.Row="0"
-											   Margin="10,0,10,10"
+											   Margin="10,0,10,-1"
 											   Grid.RowSpan="2">
 										<InlineUIContainer>
 											<kcvc:ConditionIcon ConditionType="{Binding Ship.ConditionType, Mode=OneWay}" />
 										</InlineUIContainer>
 										<Run Text="{Binding Ship.Condition, Mode=OneWay}"
 											 Style="{DynamicResource EmphaticTextElementStyleKey}" />
-									</TextBlock>
-									<TextBlock Grid.Column="5"
-											   Grid.Row="1"
-											   Margin="10,0,10,-1">
-										<Run Text="condition"
+                                        <LineBreak />
+                                        <Run Text="condition"
 											 FontSize="9" />
 
                                         <TextBlock.ToolTip>
@@ -237,18 +234,17 @@
                                         </TextBlock.ToolTip>
 									</TextBlock>
 
-									<kcvc:ColorIndicator Grid.Column="6"
-														 Grid.Row="0"
-														 Width="55"
-														 LimitedValue="{Binding Ship.Fuel, Mode=OneWay}"
-														 Height="6"
-														 Margin="0,6,0,7" />
-									<kcvc:ColorIndicator Grid.Column="6"
-														 Grid.Row="1"
-														 Width="55"
-														 LimitedValue="{Binding Ship.Bull, Mode=OneWay}"
-														 Height="6"
-														 VerticalAlignment="Top" />
+                                    <StackPanel Grid.Column="6"
+                                                Grid.RowSpan="2">
+                                        <kcvc:ColorIndicator Width="55"
+														     LimitedValue="{Binding Ship.Fuel, Mode=OneWay}"
+														     Height="6"
+														     Margin="0,6,0,7" />
+                                        <kcvc:ColorIndicator Width="55"
+														     LimitedValue="{Binding Ship.Bull, Mode=OneWay}"
+														     Height="6"
+														     VerticalAlignment="Top" />
+                                    </StackPanel>
 
 									<ItemsControl Grid.Column="7"
 												  Grid.Row="0"

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -227,6 +227,14 @@
 											   Margin="10,0,10,-1">
 										<Run Text="condition"
 											 FontSize="9" />
+
+                                        <TextBlock.ToolTip>
+                                            <TextBlock Style="{DynamicResource DefaultTextStyleKey}"
+                                                       Foreground="White">
+                                                <Run Text="피로회복까지:" />
+                                                <Run Text="{Binding Condition.ConditionText, Mode=OneWay}" />
+                                            </TextBlock>
+                                        </TextBlock.ToolTip>
 									</TextBlock>
 
 									<kcvc:ColorIndicator Grid.Column="6"

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Overview.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Overview.xaml
@@ -224,18 +224,26 @@
 														   HorizontalAlignment="Center" />
 											</Grid>
 
-											<TextBlock Grid.Column="3">
-												<InlineUIContainer>
-													<kcvc:ConditionIcon ConditionType="{Binding Ship.ConditionType, Mode=OneWay}" />
-												</InlineUIContainer>
-												<Run Text="{Binding Ship.Condition, Mode=OneWay}"
-													 Style="{DynamicResource EmphaticTextElementStyleKey}" />
-												<LineBreak />
-												<Run Text="condition"
-													 FontSize="9" />
-											</TextBlock>
-										</Grid>
-										<Rectangle Height=".99"
+												<TextBlock Grid.Column="3">
+												    <InlineUIContainer>
+													    <kcvc:ConditionIcon ConditionType="{Binding Ship.ConditionType, Mode=OneWay}" />
+												    </InlineUIContainer>
+												    <Run Text="{Binding Ship.Condition, Mode=OneWay}"
+													     Style="{DynamicResource EmphaticTextElementStyleKey}" />
+												    <LineBreak />
+												    <Run Text="condition"
+													     FontSize="8" />
+                                                    
+                                                    <TextBlock.ToolTip>
+                                                        <TextBlock Style="{DynamicResource DefaultTextStyleKey}"
+                                                                   Foreground="White">
+                                                            <Run Text="피로회복까지:" />
+                                                            <Run Text="{Binding Condition.ConditionText, Mode=OneWay}" />
+                                                        </TextBlock>
+                                                    </TextBlock.ToolTip>
+												</TextBlock>
+											</Grid>
+											<Rectangle Height=".99"
 												   Margin="0,4,0,0"
 												   Style="{DynamicResource SeparatorRectangleStyleKey}" />
 									</StackPanel>

--- a/source/Grabacr07.KanColleViewer/Views/FleetWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/FleetWindow.xaml
@@ -170,13 +170,13 @@
 								<Run Text="Condition"
 									 FontSize="10" />
 
-                                <TextBlock.ToolTip>
-                                    <TextBlock Style="{DynamicResource DefaultTextStyleKey}"
-                                               Foreground="White">
-                                        <Run Text="피로회복까지:" />
-                                        <Run Text="{Binding Condition.ConditionText, Mode=OneWay}" />
-                                    </TextBlock>
-                                </TextBlock.ToolTip>
+								<TextBlock.ToolTip>
+									<TextBlock Style="{DynamicResource DefaultTextStyleKey}"
+											   Foreground="White">
+										<Run Text="疲労回復まで:" />
+										<Run Text="{Binding Condition.ConditionText, Mode=OneWay}" />
+									</TextBlock>
+								</TextBlock.ToolTip>
 							</TextBlock>
 
 
@@ -685,11 +685,7 @@
 								   VerticalAlignment="Bottom"
 								   Margin="4,2">
 							<FrameworkElement.ToolTip>
-<<<<<<< HEAD
 								<TextBlock Text="全艦載機で、内部熟練度を最大として計算しています。"
-=======
-								<TextBlock Text="모든 함재기에서 내부숙련도를 최대로 계산합니다"
->>>>>>> 6f4bff9... 종합, 함대, 함대창에서 컨디션 툴팁에 개별 컨디션 회복시간 표시
 										   Style="{DynamicResource DefaultTextStyleKey}" />
 							</FrameworkElement.ToolTip>
 							<Run Text="{Binding State.MaxAirSuperiorityPotential, Mode=OneWay}" />

--- a/source/Grabacr07.KanColleViewer/Views/FleetWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/FleetWindow.xaml
@@ -169,6 +169,14 @@
 								<LineBreak />
 								<Run Text="Condition"
 									 FontSize="10" />
+
+                                <TextBlock.ToolTip>
+                                    <TextBlock Style="{DynamicResource DefaultTextStyleKey}"
+                                               Foreground="White">
+                                        <Run Text="피로회복까지:" />
+                                        <Run Text="{Binding Condition.ConditionText, Mode=OneWay}" />
+                                    </TextBlock>
+                                </TextBlock.ToolTip>
 							</TextBlock>
 
 
@@ -677,7 +685,11 @@
 								   VerticalAlignment="Bottom"
 								   Margin="4,2">
 							<FrameworkElement.ToolTip>
+<<<<<<< HEAD
 								<TextBlock Text="全艦載機で、内部熟練度を最大として計算しています。"
+=======
+								<TextBlock Text="모든 함재기에서 내부숙련도를 최대로 계산합니다"
+>>>>>>> 6f4bff9... 종합, 함대, 함대창에서 컨디션 툴팁에 개별 컨디션 회복시간 표시
 										   Style="{DynamicResource DefaultTextStyleKey}" />
 							</FrameworkElement.ToolTip>
 							<Run Text="{Binding State.MaxAirSuperiorityPotential, Mode=OneWay}" />


### PR DESCRIPTION
![089](https://cloud.githubusercontent.com/assets/20940566/17785812/335b98dc-65bd-11e6-9013-82c42540e2f6.PNG)

Tooltipを新しく開かなくても自動的に更新されます。
有名な3-2-1レベリングなどに役になります。（本人が使用中）

Tooltipのテキストは「疲労回復まで」です。