### PR TITLE
バックグラウンドでGCをするクラスを追加

### DIFF
--- a/source/Grabacr07.KanColleViewer/Application.xaml.cs
+++ b/source/Grabacr07.KanColleViewer/Application.xaml.cs
@@ -42,6 +42,8 @@ namespace Grabacr07.KanColleViewer
 
 	sealed partial class Application : INotifyPropertyChanged, IDisposableHolder
 	{
+		private GCWorker bgGCWorker { get; set; }
+
 		static Application()
 		{
 			AppDomain.CurrentDomain.UnhandledException += (sender, args) => ReportException(sender, args.ExceptionObject as Exception);
@@ -64,6 +66,7 @@ namespace Grabacr07.KanColleViewer
 		protected override void OnStartup(StartupEventArgs e)
 		{
 			this.ChangeState(ApplicationState.Startup);
+			bgGCWorker = new GCWorker();
 
 			// 開発中に多重起動検知ついてると起動できなくて鬱陶しいので
 			// デバッグ時は外すんじゃもん
@@ -164,6 +167,7 @@ namespace Grabacr07.KanColleViewer
 			base.OnExit(e);
 
 			this.compositeDisposable.Dispose();
+			bgGCWorker.Dispose();
 		}
 
 		/// <summary>

--- a/source/Grabacr07.KanColleViewer/KanColleViewer.csproj
+++ b/source/Grabacr07.KanColleViewer/KanColleViewer.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Composition\PluginMetadata.cs" />
     <Compile Include="Models\BrowserZoomFactor.cs" />
     <Compile Include="Models\ExitConfirmationType.cs" />
+    <Compile Include="Models\GCWorker.cs" />
     <Compile Include="Models\IZoomFactor.cs" />
     <Compile Include="Models\NotifierHost.cs" />
     <Compile Include="Models\ProductInfo.cs" />

--- a/source/Grabacr07.KanColleViewer/Models/GCWorker.cs
+++ b/source/Grabacr07.KanColleViewer/Models/GCWorker.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Grabacr07.KanColleViewer.Models
+{
+	internal sealed class GCWorker : IDisposable
+	{
+		[DllImport("kernel32.dll", EntryPoint = "SetProcessWorkingSetSize", SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+		private static extern bool SetProcessWorkingSetSize(IntPtr proc, int min, int max);
+
+		private bool GCWorking { get; set; } = false;
+		private Thread GCThread { get; }
+
+		public GCWorker()
+		{
+			GCThread = new Thread(() =>
+			{
+				int cnt = 60 * 5;
+				while (GCWorking)
+				{
+					Thread.Sleep(1000);
+					if (!GCWorking) break;
+
+					cnt--;
+					if (cnt == 0)
+					{
+						cnt = 60 * 5;
+						this.Collect();
+					}
+				}
+			});
+
+			GCWorking = true;
+			GCThread.Start();
+		}
+		private void Collect()
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+				SetProcessWorkingSetSize(Process.GetCurrentProcess().Handle, -1, -1);
+		}
+
+		~GCWorker()
+		{
+			this.Dispose();
+		}
+		public void Dispose()
+		{
+			GC.SuppressFinalize(this);
+			GCWorking = false;
+		}
+	}
+}


### PR DESCRIPTION
すでにご存知だと思いますが、KanColleViewerのメモリ使用量は極悪です。
プレイして間もなく何百MBを使い、出撃や編成、建造と開発をするとするほどメモリが増えます。

もちろんビュアーの問題ではありません。C#のメモリ・アロケーションの構造的問題です。
これはGCを直接コールすると解決しますが、ゲームのFlashが使う量もあるので、現在のメモリサイズで判断するのはできません。

で、バックグラウンドスレッドで一定時間ごとにGCすることにしました。適用してみた結果、GC時にフリーズするタイムもほぼ無く、効果的に整理されました。
## 

![202](https://cloud.githubusercontent.com/assets/20940566/19486160/7d331538-9598-11e6-9cb2-a94ccd9687a6.png)
適用前に出撃1回したメモリです。
軽く400MB超えました。

![203](https://cloud.githubusercontent.com/assets/20940566/19486236/b4b334b6-9598-11e6-96e3-d504b65eeef7.PNG)
そしてこれがGCWorker追加後のメモリです。
出撃数回、任務更新、編成変更、図鑑で全艦娘みるなどなどの行為をしてもあの量です。
あれが平均メモリ量です。
## 

今のソースでは5分ごとに整理するようにしていますが、必要によって調整してください。

GC.Collect でC#のメモリを、SetProcessWorkingSetSize でシステムレベルのメモリを整理します。
SetProcessWorkingSetSize はWin32APIなので Environment.OSVersion.Platform チェックしました。
