### PR TITLE
2020/03/27の任務画面UIアップデートに対応

### DIFF
--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_quest.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_quest.cs
@@ -12,9 +12,11 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 		public int api_no { get; set; }
 		public int api_category { get; set; }
 		public int api_type { get; set; }
+		public int api_label_type { get; set; }
 		public int api_state { get; set; }
 		public string api_title { get; set; }
 		public string api_detail { get; set; }
+		public int api_voice_id { get; set; }
 		public int[] api_get_material { get; set; }
 		public int api_bonus_flag { get; set; }
 		public int api_progress_flag { get; set; }

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_questlist.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_questlist.cs
@@ -10,10 +10,10 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 	public class kcsapi_questlist
 	{
 		public int api_count { get; set; }
-		public int api_page_count { get; set; }
-		public int api_disp_page { get; set; }
-		public kcsapi_quest[] api_list { get; set; }
+		public int api_completed_kind { get; set; }
 		public int api_exec_count { get; set; }
+		public kcsapi_quest[] api_list { get; set; }
+		public int api_exec_type { get; set; }
 	}
 	// ReSharper restore InconsistentNaming
 }


### PR DESCRIPTION
2020/03/27の任務画面UIアップデートに伴う /kcsapi/api_get_member/questlist APIのレスポンス構造変更に対応

- レスポンスのページング廃止に対応
- スキーマ変更に対応
- 任務画面左タブ「全 All」以外を選択している場合のレスポンスを使用しても問題ないようだったので制限を撤廃。