### PR TITLE
Increase frame rate range to 60 fps

### DIFF
--- a/source/Grabacr07.KanColleViewer/Views/Controls/KanColleHost.cs
+++ b/source/Grabacr07.KanColleViewer/Views/Controls/KanColleHost.cs
@@ -45,9 +45,10 @@ namespace Grabacr07.KanColleViewer.Views.Controls
 			DependencyProperty.Register(nameof(WebBrowser), typeof(ChromiumWebBrowser), typeof(KanColleHost), new UIPropertyMetadata(null, WebBrowserPropertyChangedCallback));
 
 		private static void WebBrowserPropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
-		{
+		{		
 			var instance = (KanColleHost)d;
 			var newBrowser = (ChromiumWebBrowser)e.NewValue;
+			newBrowser.BrowserSettings.WindowlessFrameRate = 60;
 			var oldBrowser = (ChromiumWebBrowser)e.OldValue;
 
 			if (oldBrowser != null)


### PR DESCRIPTION
Most modern monitors refresh normally at 60 Hz, while default maximum value of frame rate about CEF is 30 fps,  which means out-of-dated.
And this branch increases the range upto 60 fps.