### PR TITLE
fix bugs for function of developing equipments including concentrated development

### DIFF
--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/CreatedSlotItemViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/CreatedSlotItemViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -56,7 +56,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 		public void Update(CreatedSlotItem item)
 		{
 			this.Succeed = item.Succeed;
-			this.Name = item.SlotItemInfo.Name;
+			this.Name = !item.Succeed ? "-----"
+				: string.Join(Environment.NewLine, item.SlotItemInfos.Select(x => x.Name).ToArray());
 		}
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/Itemyard.cs
+++ b/source/Grabacr07.KanColleWrapper/Itemyard.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -132,9 +132,12 @@ namespace Grabacr07.KanColleWrapper
 
 		private void CreateItem(kcsapi_createitem source)
 		{
-			if (source.api_create_flag == 1 && source.api_slot_item != null)
+			if (source.api_create_flag == 1 && source.api_get_items != null)
 			{
-				this.SlotItems.Add(new SlotItem(source.api_slot_item));
+				foreach (var x in source.api_get_items)
+				{
+					if (x.api_slotitem_id != -1) this.SlotItems.Add(new SlotItem(x));
+				}				
 			}
 			this.RaiseSlotItemsChanged();
 		}

--- a/source/Grabacr07.KanColleWrapper/Models/CreatedSlotItem.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/CreatedSlotItem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -13,18 +13,21 @@ namespace Grabacr07.KanColleWrapper.Models
 	{
 		public bool Succeed => this.RawData.api_create_flag == 1;
 
-		public SlotItemInfo SlotItemInfo { get; }
+		public List<SlotItemInfo> SlotItemInfos { get; }
 
 		public CreatedSlotItem(kcsapi_createitem rawData)
 			: base(rawData)
 		{
 			try
 			{
-				this.SlotItemInfo = this.Succeed
-					? KanColleClient.Current.Master.SlotItems[rawData.api_slot_item.api_slotitem_id]
-					: KanColleClient.Current.Master.SlotItems[int.Parse(rawData.api_fdata.Split(',')[1])];
+				this.SlotItemInfos = this.Succeed
+					? new List<SlotItemInfo>(
+						rawData.api_get_items
+						.Where(x => x.api_slotitem_id != -1)
+						.Select(x => KanColleClient.Current.Master.SlotItems[x.api_slotitem_id]))
+					: null;
 
-				System.Diagnostics.Debug.WriteLine("createitem: {0} - {1}", this.Succeed, this.SlotItemInfo.Name);
+				//System.Diagnostics.Debug.WriteLine("createitem: {0} - {1}", this.Succeed, this.SlotItemInfos.Name);
 			}
 			catch (Exception ex)
 			{

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_createitem.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_createitem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,15 +9,19 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 	// ReSharper disable InconsistentNaming
 	public class kcsapi_createitem
 	{
-		public int api_id { get; set; }
-		public int api_slotitem_id { get; set; }
 		public int api_create_flag { get; set; }
-		public int api_shizai_flag { get; set; }
-		public kcsapi_slotitem api_slot_item { get; set; }
+		public kcsapi_slotitem[] api_get_items { get; set; }
 		public int[] api_material { get; set; }
+		public kcsapi_createitem_unset_items[] kcsapi_unset_items { get; set; }		
+		//public int api_id { get; set; }
+		//public int api_slotitem_id { get; set; }
+		//public int api_shizai_flag { get; set; }
+		//public string api_fdata { get; set; }
+	}
+	public class kcsapi_createitem_unset_items
+	{
 		public int api_type3 { get; set; }
-		public int[] api_unsetslot { get; set; }
-		public string api_fdata { get; set; }
+		public int api_slot_list { get; set; }
 	}
 	// ReSharper restore InconsistentNaming
 }


### PR DESCRIPTION
related: #245 
The APIs of create item (装備開発) has been changed before, which makes KCV failed to show the name of equipment in Dockyard Selection.
Additionally,the feature of concentrated development (集中開発) is to create 3 items one time, however only the last result could be observed in KCV due to outdated data structure.
This branch may fix those problems.